### PR TITLE
Modifs checks

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -278,7 +278,9 @@ class OrangeContentScript extends ContentScript {
     await this.runInWorker('checkInfosConfirmation')
     await this.waitForElementInWorker(`a[href="${DEFAULT_PAGE_URL}"`)
     await this.clickAndWait(`a[href="${DEFAULT_PAGE_URL}"`, 'strong')
-    const billsPage = await this.runInWorker('checkBillsElement')
+    const billsPage = await this.runInWorkerUntilTrue({
+      method: 'checkBillsElement'
+    })
     if (!billsPage) {
       this.log('warn', 'Cannot find a path to the bills page')
       throw new Error('Cannot find a path to bill Page, aborting execution')

--- a/src/index.js
+++ b/src/index.js
@@ -307,15 +307,33 @@ class OrangeContentScript extends ContentScript {
     let allPdfNumber = await this.runInWorker('getPdfNumber')
     let oldPdfNumber = allPdfNumber - recentPdfNumber
     for (let i = 0; i < recentPdfNumber; i++) {
+      this.log('info', `Before clicking ${i} recent pdf`)
       await this.runInWorker('waitForRecentPdfClicked', i)
+      let redFrame = await this.runInWorker('checkRedFrame')
+      if (redFrame !== null) {
+        this.log('warn', 'Website did not load the bills')
+        throw new Error('VENDOR_DOWN')
+      }
+      this.log('info', `After clicking ${i} recent pdf`)
       await this.clickAndWait(
         'a[class="h1 menu-subtitle mb-0 pb-1"]',
         '[data-e2e="bp-tile-historic"]'
       )
+      redFrame = await this.runInWorker('checkRedFrame')
+      if (redFrame !== null) {
+        this.log('warn', 'Website did not load the bills')
+        throw new Error('VENDOR_DOWN')
+      }
+      this.log('info', `Back to bill list ${i} recent pdf`)
       await this.clickAndWait(
         '[data-e2e="bp-tile-historic"]',
         '[aria-labelledby="bp-billsHistoryTitle"]'
       )
+      redFrame = await this.runInWorker('checkRedFrame')
+      if (redFrame !== null) {
+        this.log('warn', 'Website did not load the bills')
+        throw new Error('VENDOR_DOWN')
+      }
       await this.clickAndWait(
         '[data-e2e="bh-more-bills"]',
         '[aria-labelledby="bp-historicBillsHistoryTitle"]'
@@ -323,15 +341,33 @@ class OrangeContentScript extends ContentScript {
     }
     this.log('info', 'recentPdf loop ended')
     for (let i = 0; i < oldPdfNumber; i++) {
+      this.log('info', `Before clicking ${i} old pdf`)
       await this.runInWorker('waitForOldPdfClicked', i)
+      let redFrame = await this.runInWorker('checkRedFrame')
+      if (redFrame !== null) {
+        this.log('warn', 'Website did not load the bills')
+        throw new Error('VENDOR_DOWN')
+      }
+      this.log('info', `After clicking ${i} old pdf`)
       await this.clickAndWait(
         'a[class="h1 menu-subtitle mb-0 pb-1"]',
         '[data-e2e="bp-tile-historic"]'
       )
+      redFrame = await this.runInWorker('checkRedFrame')
+      if (redFrame !== null) {
+        this.log('warn', 'Website did not load the bills')
+        throw new Error('VENDOR_DOWN')
+      }
+      this.log('info', `Back to bill list ${i} old pdf`)
       await this.clickAndWait(
         '[data-e2e="bp-tile-historic"]',
         '[aria-labelledby="bp-billsHistoryTitle"]'
       )
+      redFrame = await this.runInWorker('checkRedFrame')
+      if (redFrame !== null) {
+        this.log('warn', 'Website did not load the bills')
+        throw new Error('VENDOR_DOWN')
+      }
       await this.clickAndWait(
         '[data-e2e="bh-more-bills"]',
         '[aria-labelledby="bp-historicBillsHistoryTitle"]'


### PR DESCRIPTION
We needed to change the execution of the 'checkBillsPage' method to `runInWorkerUntilTrue` to be sure the check is correctly hendled.

We also add the redFrame checking (when bills has not been loaded by the website) after every click during pdfs collection as it could happen for every pdfs we try to get. 