### PR TITLE
feat: Do not set a default sourceAccountIdentifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "dependencies": {
     "@cozy/minilog": "1.0.0",
     "cozy-clisk": "^0.22.2",
-    "date-fns": "2.29.3"
+    "date-fns": "2.29.3",
+    "p-wait-for": "5.0.2"
   },
   "eslintConfig": {
     "extends": [

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,6 @@ Minilog.enable('orangeCCC')
 
 const BASE_URL = 'https://espace-client.orange.fr'
 const DEFAULT_PAGE_URL = BASE_URL + '/accueil'
-const DEFAULT_SOURCE_ACCOUNT_IDENTIFIER = 'orange'
 const LOGIN_FORM_PAGE = 'https://login.orange.fr/'
 
 let recentBills = []
@@ -114,7 +113,7 @@ class OrangeContentScript extends ContentScript {
   }
 
   async ensureAuthenticated() {
-    this.log('info', 'ensureAuthenticated starts')
+    this.log('info', '🤖 ensureAuthenticated starts')
     await this.navigateToLoginForm()
     const credentials = await this.getCredentials()
     await this.waitForElementInWorker('#o-ribbon')
@@ -204,7 +203,7 @@ class OrangeContentScript extends ContentScript {
   }
 
   async ensureNotAuthenticated() {
-    this.log('info', 'ensureNotAuthenticated starts')
+    this.log('info', '🤖 ensureNotAuthenticated starts')
     await this.navigateToLoginForm()
     const authenticated = await this.runInWorker('checkAuthenticated')
     if (!authenticated) {
@@ -289,7 +288,7 @@ class OrangeContentScript extends ContentScript {
   }
 
   async fetch(context) {
-    this.log('info', 'Starting fetch')
+    this.log('info', '🤖 fetch start')
     if (this.store.userCredentials != undefined) {
       await this.saveCredentials(this.store.userCredentials)
     }
@@ -585,11 +584,11 @@ class OrangeContentScript extends ContentScript {
   }
 
   async getUserDataFromWebsite() {
+    this.log('info', '🤖 getUserDataFromWebsite starts')
     await this.waitForElementInWorker('.o-identityLayer-detail')
     const sourceAccountId = await this.runInWorker('getUserMail')
     if (sourceAccountId === 'UNKNOWN_ERROR') {
-      this.log('warn', "Couldn't get a sourceAccountIdentifier, using default")
-      return { sourceAccountIdentifier: DEFAULT_SOURCE_ACCOUNT_IDENTIFIER }
+      throw new Error('Could not get a sourceAccountIdentifier')
     }
     return {
       sourceAccountIdentifier: sourceAccountId

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,8 @@
 import { ContentScript } from 'cozy-clisk/dist/contentscript'
 import { blobToBase64 } from 'cozy-clisk/dist/contentscript/utils'
 import Minilog from '@cozy/minilog'
+import waitFor from 'p-wait-for'
+
 const log = Minilog('ContentScript')
 Minilog.enable('orangeCCC')
 
@@ -790,7 +792,7 @@ class OrangeContentScript extends ContentScript {
     return false
   }
 
-  async waitForCaptchaResolution() {
+  async checkCaptchaResolution() {
     const passwordInput = document.querySelector('#password')
     const loginInput = document.querySelector('#login')
     const stayLoggedButton = document.querySelector(
@@ -801,6 +803,14 @@ class OrangeContentScript extends ContentScript {
       return true
     }
     return false
+  }
+
+  async waitForCaptchaResolution() {
+    await waitFor(this.checkCaptchaResolution, {
+      interval: 1000,
+      timeout: 60 * 1000
+    })
+    return true
   }
 
   async checkAccountListPage() {
@@ -828,6 +838,13 @@ class OrangeContentScript extends ContentScript {
     const digestId = await hashVendorRef(vendorRef)
     const shortenedId = digestId.substr(0, 5)
     return `${date}_orange_${amount}€_${shortenedId}.pdf`
+  }
+  async waitForBillsElement() {
+    await waitFor(this.checkBillsElement, {
+      interval: 1000,
+      timeout: 30 * 1000
+    })
+    return true
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3750,7 +3750,7 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
-p-wait-for@^5.0.2:
+p-wait-for@5.0.2, p-wait-for@^5.0.2:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/p-wait-for/-/p-wait-for-5.0.2.tgz#1546a15e64accf1897377cb1507fa4c756fffe96"
   integrity sha512-lwx6u1CotQYPVju77R+D0vFomni/AqRfqLmqQ8hekklqZ6gAY9rONh7lBQ0uxWMkC2AuX9b2DVAl8To0NyP1JA==


### PR DESCRIPTION
This may cause silent errors later, it is better to fail in this case.
- feat: Do not set a default sourceAccountIdentifier
- fix: Add waitFor in runInWorkerUntilTrue
