### PR TITLE
fix: Avoid switch to sosh or orange iphone app while running orange konnector

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -293,7 +293,8 @@ class OrangeContentScript extends ContentScript {
     }
     await this.runInWorker('checkInfosConfirmation')
     await this.waitForElementInWorker(`a[href="${DEFAULT_PAGE_URL}"`)
-    await this.clickAndWait(`a[href="${DEFAULT_PAGE_URL}"`, 'strong')
+    await this.goto(DEFAULT_PAGE_URL)
+    await this.waitForElementInWorker('strong')
     const billsPage = await this.runInWorkerUntilTrue({
       method: 'checkBillsElement'
     })

--- a/src/index.js
+++ b/src/index.js
@@ -826,8 +826,7 @@ class OrangeContentScript extends ContentScript {
     return false
   }
 
-  async checkBillsElement() {
-    this.log('info', 'checkBillsElement starts')
+  async findAndClickBillsElement() {
     const strongElements = document.querySelectorAll('strong')
     for (const element of strongElements) {
       if (element.textContent === 'Factures et paiements') {
@@ -837,6 +836,13 @@ class OrangeContentScript extends ContentScript {
       }
     }
     return false
+  }
+  async checkBillsElement() {
+    await waitFor(this.findAndClickBillsElement.bind(this), {
+      interval: 1000,
+      timeout: 30 * 1000
+    })
+    return true
   }
 
   async getFileName(date, amount, vendorRef) {

--- a/src/index.js
+++ b/src/index.js
@@ -114,8 +114,11 @@ class OrangeContentScript extends ContentScript {
     }
   }
 
-  async ensureAuthenticated() {
+  async ensureAuthenticated({ account }) {
     this.log('info', '🤖 ensureAuthenticated starts')
+    if (!account) {
+      await this.ensureNotAuthenticated()
+    }
     await this.navigateToLoginForm()
     const credentials = await this.getCredentials()
     await this.waitForElementInWorker('#o-ribbon')
@@ -176,8 +179,7 @@ class OrangeContentScript extends ContentScript {
         await this.tryAutoLogin(credentials, 'full')
         return true
       }
-    }
-    if (!credentials) {
+    } else {
       this.log('info', 'no credentials found, use normal user login')
       const rememberUser = await this.runInWorker('checkIfRemember')
       if (rememberUser) {


### PR DESCRIPTION
- fix: Avoid switch to sosh or orange iphone app while running orange konnector
- fix: Run ensureNotAuthenticated on first run
- fix: All methods run by runInWorkerUntilTrue must use waitfor
