### PR TITLE
fix: Add a check and a goto if no idLinkButton found

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -332,13 +332,19 @@ class OrangeContentScript extends ContentScript {
 
   async navigateToPersonalInfos() {
     this.log('info', 'navigateToPersonalInfos starts')
-    await this.clickAndWait(
-      '#o-identityLink',
-      'a[data-oevent-action="infospersonnelles"]'
-    )
-
-    await this.runInWorker('click', 'a[data-oevent-action="infospersonnelles"]')
-
+    if (!(await this.isElementInWorker('#o-identityLink'))) {
+      this.log('info', 'Cannot find the identityLinkButton, trying with a goto')
+      await this.goto('https://espace-client.orange.fr/compte')
+    } else {
+      await this.clickAndWait(
+        '#o-identityLink',
+        'a[data-oevent-action="infospersonnelles"]'
+      )
+      await this.runInWorker(
+        'click',
+        'a[data-oevent-action="infospersonnelles"]'
+      )
+    }
     await this.waitForElementInWorker('span', {
       includesText: 'Infos personnelles'
     })


### PR DESCRIPTION
This PR adds a check on the identityLinkButton we are supposed to click to reach the personnalInfosPage.
Some user cannot find this button at this step of the execution, and we're not really sure why, so it's a little workaround to try and get the personnalInfos page if the button is not present.

Concerned users will be put in debug mode so if this pop again in near future, we'll get more infos.