### PR TITLE
Feat/ensureNotAuth

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -229,7 +229,7 @@ class OrangeContentScript extends ContentScript {
     if (this.store.userCredentials != undefined) {
       await this.saveCredentials(this.store.userCredentials)
     }
-    await this.goto('https://espace-client.orange.fr/accueil')
+    await this.goto(DEFAULT_PAGE_URL)
     await this.waitForElementInWorker('.menu')
     const contracts = await this.runInWorker('getContracts')
     let counter = 1
@@ -479,8 +479,13 @@ class OrangeContentScript extends ContentScript {
         givenName: interceptor.userInfos.identification?.identity?.firstName,
         lastName: interceptor.userInfos.identification?.identity?.lastName
       },
-      mail: interceptor.userInfos.identification?.contactInformation?.email
-        ?.address,
+      mail: [
+        {
+          address:
+            interceptor.userInfos.identification?.contactInformation?.email
+              ?.address
+        }
+      ],
       address
     }
 
@@ -492,7 +497,6 @@ class OrangeContentScript extends ContentScript {
         }
       ]
     }
-
     await this.sendToPilot({
       infosIdentity
     })

--- a/src/index.js
+++ b/src/index.js
@@ -144,7 +144,6 @@ class OrangeContentScript extends ContentScript {
       this.log('info', 'no credentials found, use normal user login')
       await this.waitForUserAuthentication()
     }
-    await this.detectSoshOnlyAccount()
   }
 
   async checkAuthenticated() {
@@ -567,23 +566,6 @@ class OrangeContentScript extends ContentScript {
     if (redFrame) return redFrame
     if (oldBillsRedFrame) return oldBillsRedFrame
     return null
-  }
-
-  async detectSoshOnlyAccount() {
-    await this.runInWorker('checkInfosConfirmation')
-    await this.waitForElementInWorker(`a[href="${DEFAULT_PAGE_URL}"`)
-    await this.goto(DEFAULT_PAGE_URL)
-    await this.waitForElementInWorker('strong')
-    const isSosh = await this.runInWorker(
-      'checkForElement',
-      `#oecs__logo[href="https://www.sosh.fr/"]`
-    )
-    this.log('info', 'isSosh ' + isSosh)
-    if (isSosh) {
-      throw new Error(
-        'This should be an orange account. Found only sosh contracts'
-      )
-    }
   }
 
   async getTestEmail() {


### PR DESCRIPTION
This PR adds the ensureNotAuthenticated function that forces logout on first konnector execution if needed

It also fixes :
- All known scenarios for login/autoLogin/logout
- Modifies credentials interceptions using worker event instead of findAndSendCredentials to fit with the actual standards 
- Tiny changes in identity's mail format.
- Removes detectSoshAccountOnly as it was not used anymore
