### PR TITLE
feat: Add context upgrades

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -374,7 +374,9 @@ class OrangeContentScript extends ContentScript {
         vendorId: contract.cid,
         brand: contract.brand.toLowerCase(),
         // eslint-disable-next-line no-useless-escape
-        label: contract.offerName.match(/^(.*?)(\d{1,3}(?:\,\d{1,2})?)?€?$/)[1],
+        label: contract.offerName.match(/\d{1,3},\d{2}€/)
+          ? contract.offerName.replace(/\s\d{1,3},\d{2}€/, '')
+          : contract.offerName,
         type: contract.vertical.toLowerCase() === 'mobile' ? 'phone' : 'isp',
         holder: contract.holder,
         number: contract.telco.publicNumber

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,7 @@ const JSON_HEADERS = {
 const BASE_URL = 'https://espace-client.orange.fr'
 const DEFAULT_PAGE_URL = BASE_URL + '/accueil'
 const LOGIN_FORM_PAGE = 'https://login.orange.fr/'
+let FORCE_FETCH_ALL = false
 
 const interceptor = new XhrInterceptor()
 interceptor.init()
@@ -297,6 +298,7 @@ class OrangeContentScript extends ContentScript {
 
   async fetch(context) {
     this.log('info', '🤖 fetch start')
+    const distanceInDays = await this.handleContextInfos(context)
     if (this.store.userCredentials != undefined) {
       await this.saveCredentials(this.store.userCredentials)
     }
@@ -307,7 +309,8 @@ class OrangeContentScript extends ContentScript {
     for (const contract of contracts) {
       this.log('info', `Fetching ${counter}/${contracts.length} contract`)
       const { recentBills, oldBillsUrl } = await this.fetchRecentBills(
-        contract.vendorId
+        contract.vendorId,
+        distanceInDays
       )
       await this.saveBills(recentBills, {
         context,
@@ -317,18 +320,20 @@ class OrangeContentScript extends ContentScript {
         qualificationLabel:
           contract.type === 'phone' ? 'phone_invoice' : 'isp_invoice'
       })
-      const oldBills = await this.fetchOldBills({
-        oldBillsUrl,
-        vendorId: contract.vendorId
-      })
-      await this.saveBills(oldBills, {
-        context,
-        fileIdAttributes: ['vendorRef'],
-        contentType: 'application/pdf',
-        subPath: `${contract.number} - ${contract.label} - ${contract.vendorId}`,
-        qualificationLabel:
-          contract.type === 'phone' ? 'phone_invoice' : 'isp_invoice'
-      })
+      if (FORCE_FETCH_ALL) {
+        const oldBills = await this.fetchOldBills({
+          oldBillsUrl,
+          vendorId: contract.vendorId
+        })
+        await this.saveBills(oldBills, {
+          context,
+          fileIdAttributes: ['vendorRef'],
+          contentType: 'application/pdf',
+          subPath: `${contract.number} - ${contract.label} - ${contract.vendorId}`,
+          qualificationLabel:
+            contract.type === 'phone' ? 'phone_invoice' : 'isp_invoice'
+        })
+      }
       counter++
     }
 
@@ -337,6 +342,29 @@ class OrangeContentScript extends ContentScript {
     await this.saveIdentity({ contact: this.store.infosIdentity })
     // Logging out every run to avoid in between scenarios and sosh/orange mismatched sessions
     await this.logout()
+  }
+
+  async handleContextInfos(context) {
+    this.log('info', '📍️ handleContextInfos starts')
+    const { trigger } = context
+    // force fetch all data (the long way) when last trigger execution is older than 90 days
+    // or when the last job was an error
+    const isLastJobError =
+      trigger.current_state?.last_failure > trigger.current_state?.last_success
+    const hasLastExecution = Boolean(trigger.current_state?.last_execution)
+    const distanceInDays = getDateDistanceInDays(
+      trigger.current_state?.last_execution
+    )
+    this.log('debug', `distanceInDays: ${distanceInDays}`)
+    if (distanceInDays >= 90 || !hasLastExecution || isLastJobError) {
+      this.log('info', '🐢️ Long execution')
+      this.log('debug', `isLastJobError: ${isLastJobError}`)
+      this.log('debug', `hasLastExecution: ${hasLastExecution}`)
+      FORCE_FETCH_ALL = true
+    } else {
+      this.log('info', '🐇️ Quick execution')
+    }
+    return distanceInDays
   }
 
   async getContracts() {
@@ -407,7 +435,7 @@ class OrangeContentScript extends ContentScript {
     return interceptor.recentBills
   }
 
-  async fetchRecentBills(vendorId) {
+  async fetchRecentBills(vendorId, distanceInDays) {
     await this.goto(
       'https://espace-client.orange.fr/facture-paiement/' + vendorId
     )
@@ -420,16 +448,31 @@ class OrangeContentScript extends ContentScript {
         '.alert-container alert-container-sm alert-danger mb-0'
       )
     ])
-
     const redFrame = await this.runInWorker('checkRedFrame')
     if (redFrame !== null) {
       this.log('warn', 'Website did not load the bills')
       throw new Error('VENDOR_DOWN')
     }
-
+    let billsToFetch
     const recentBills = await this.runInWorker('getRecentBillsFromInterceptor')
     const saveBillsEntries = []
-    for (const bill of recentBills.billsHistory.billList) {
+    if (!FORCE_FETCH_ALL) {
+      const allRecentBills = recentBills.billsHistory.billList
+      // FORCE_FETCH_ALL being define priorly, if we're meeting this condition,
+      // we just need to look for 3 month back maximum.
+      // In order to get the fastest execution possible, we're checking how many months we got to cover since last execution
+      // as the website is providing one bill a month in most cases, while special cases will be covered from one month to another.
+      let numberToFetch = Math.ceil(distanceInDays / 30)
+      this.log(
+        'info',
+        `Fetching ${numberToFetch} ${numberToFetch > 1 ? 'bills' : 'bill'}`
+      )
+      billsToFetch = allRecentBills.slice(0, numberToFetch)
+    } else {
+      this.log('info', 'Fetching all bills')
+      billsToFetch = recentBills.billsHistory.billList
+    }
+    for (const bill of billsToFetch) {
       const amount = bill.amount / 100
       const vendorRef = bill.id || bill.tecId
       saveBillsEntries.push({
@@ -750,4 +793,11 @@ async function hashVendorRef(vendorRef) {
   const hashArray = Array.from(new Uint8Array(hashBuffer)) // convert buffer to byte array
   const hashHex = hashArray.map(b => b.toString(16).padStart(2, '0')).join('') // convert bytes to hex string
   return hashHex
+}
+
+function getDateDistanceInDays(dateString) {
+  const distanceMs = Date.now() - new Date(dateString).getTime()
+  const days = 1000 * 60 * 60 * 24
+
+  return Math.floor(distanceMs / days)
 }


### PR DESCRIPTION
This PR adds context upgrades to provide conditions for long and quick bills fetching.

As the website gives one bill per month in most cases, when FORCE_FETCH_ALL is false, we just need to look back 3 month max, as  if distanceInDays since lastExecution is greater than 90 days, FORCE_FETCH_ALL is true.

This improves a lot the execution's speed of this konnector.