### PR TITLE
[SCR-105] fix: Fix email structure and rename it

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -732,7 +732,7 @@ class OrangeContentScript extends ContentScript {
       interceptor.userInfos.portfolio?.contracts?.[0]?.telco?.publicNumber
     const address = []
     if (addressInfos) {
-      const houseNumber = addressInfos.postalAddress?.streetNumber?.number
+      const streetNumber = addressInfos.postalAddress?.streetNumber?.number
       const streetType = addressInfos.postalAddress?.street?.type
       const streetName = addressInfos.postalAddress?.street?.name
       const street =
@@ -740,11 +740,11 @@ class OrangeContentScript extends ContentScript {
       const postCode = addressInfos.postalAddress?.postalCode
       const city = addressInfos.postalAddress?.cityName
       const formattedAddress =
-        houseNumber && street && postCode && city
-          ? `${houseNumber} ${street} ${postCode} ${city}`
+        streetNumber && street && postCode && city
+          ? `${streetNumber} ${street} ${postCode} ${city}`
           : undefined
       address.push({
-        houseNumber,
+        streetNumber,
         street,
         postCode,
         city,
@@ -757,7 +757,12 @@ class OrangeContentScript extends ContentScript {
           interceptor.identification?.contracts?.[0]?.holder?.firstName,
         lastName: interceptor.identification?.contracts?.[0]?.holder?.lastName
       },
-      mail: interceptor.identification?.contactInformation?.email?.address,
+      email: [
+        {
+          address:
+            interceptor.identification?.contactInformation?.email?.address
+        }
+      ],
       address
     }
 


### PR DESCRIPTION
This PR fixes mail structure in identityObject to fit with cozy existing docTypes.
It also change "houseNumber" to "streetNumber" for same reasons