### PR TITLE
[SCR-292] fix: Add mobileConnect state handling

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -190,6 +190,9 @@ class OrangeContentScript extends ContentScript {
     const isCaptcha = Boolean(
       document.querySelector('div[class*="captcha_responseContainer"]')
     )
+    const isMobileconnect = document.querySelector(
+      'button[data-testid="submit-mc"]'
+    )
     const elcosHeader = document.querySelector('#o-header > elcos-header')
     const isConnected = elcosHeader
       ? Boolean(
@@ -215,6 +218,7 @@ class OrangeContentScript extends ContentScript {
     else if (isCaptcha) return 'captchaPage'
     else if (isKeepConnected) return 'keepConnectedPage'
     else if (isAccountList) return 'accountListPage'
+    else if (isMobileconnect) return 'mobileConnectPage'
     else if (isReloadButton) return 'reloadButtonPage'
     else if (isDisconnected) return 'disconnectedPage'
     else if (isConsentPage) return 'consentPage'
@@ -236,7 +240,10 @@ class OrangeContentScript extends ContentScript {
           .shadowRoot.querySelector('[data-oevent-action=sedeconnecter]')
           .click()
       })
-    } else if (currentState === 'passwordAlonePage') {
+    } else if (
+      currentState === 'passwordAlonePage' ||
+      currentState === 'mobileConnectPage'
+    ) {
       await this.runInWorker('click', '[data-testid=change-account]')
     } else if (currentState === 'captchaPage') {
       await this.handleCaptcha()


### PR DESCRIPTION
This Pr adds handling when meeting the mobilConnect page, this state was handled correctly in the ensureAuthenticated function but not in the ensureNotAuthenticated function. The reload button defining the "reloadButton" state is apparently present on this page but not visible to the user, leading the loop to never stop, as this state is not "acceptable".
We're now lookin for the mobilConnect button before checking for the reloadButton, and change account if it's found to restart a proper login.