### PR TITLE
[SCR-369] Fix/bills error page

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -226,6 +226,7 @@ class OrangeContentScript extends ContentScript {
   }
 
   async triggerNextState(currentState) {
+    this.log('info', '📍️ triggerNextState starts')
     if (currentState === 'errorPage') {
       this.log('error', `Got an error page: ${window.location.href}`)
       throw new Error(`VENDOR_DOWN`)
@@ -474,8 +475,13 @@ class OrangeContentScript extends ContentScript {
     const { trigger } = context
     // force fetch all data (the long way) when last trigger execution is older than 90 days
     // or when the last job was an error
+    const isFirstJob =
+      !trigger.current_state?.last_failure &&
+      !trigger.current_state?.last_success
     const isLastJobError =
+      !isFirstJob &&
       trigger.current_state?.last_failure > trigger.current_state?.last_success
+
     const hasLastExecution = Boolean(trigger.current_state?.last_execution)
     const distanceInDays = getDateDistanceInDays(
       trigger.current_state?.last_execution


### PR DESCRIPTION
This PR fixes the FORCE_FETCH_ALL definition. 
If an error occured on first execution, the compared field "last_success" on the next execution wasn't existing leading to compare the last_failed and "undefined" resulting falsy and launching a quick execution when we wanted a long one.

It also tries to prevent error when the billsPage is not available (website side), showing an error an inviting the user to try to reload.
If we detect this behavior, we're clicking on the given reload link, and wait for the bills's historicButton or for the error to happen again.
If the error shows off, then we throw a VENDOR_DOWN, otherwise, the execution continues as expected