### PR TITLE
[SCR-737 SCR-739] Feat/avoid403

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -888,8 +888,7 @@ class OrangeContentScript extends ContentScript {
     // overload ContentScript.downloadFileInWorker to be able to check the status of the file. Since not-so-long ago, recent bills on some account are all receiving a 403 error, issue is on their side, either on browser desktop/mobile.
     // This does not affect bills older than one year (so called oldBills) for the moment
     this.log('debug', 'downloading file in worker')
-    let response
-    response = await fetch(entry.fileurl, {
+    const response = await fetch(entry.fileurl, {
       headers: {
         ...ORANGE_SPECIAL_HEADERS,
         ...JSON_HEADERS
@@ -939,11 +938,4 @@ async function hashVendorRef(vendorRef) {
   const hashArray = Array.from(new Uint8Array(hashBuffer)) // convert buffer to byte array
   const hashHex = hashArray.map(b => b.toString(16).padStart(2, '0')).join('') // convert bytes to hex string
   return hashHex
-}
-
-function getDateDistanceInDays(dateString) {
-  const distanceMs = Date.now() - new Date(dateString).getTime()
-  const days = 1000 * 60 * 60 * 24
-
-  return Math.floor(distanceMs / days)
 }


### PR DESCRIPTION
This PR adds :

- The use of  the new `shouldFullSync` librairy's function to handle context info. Used to know if a full sync (long way) is required or not, and if not, how many days have past since last execution (30 days max before doing a fullSync anyway)

- an override of the downloadInWorker function similar to Sosh's to avoid potential 403 error user can encouter on the website latetly. Despite having bills to download, even on browser the website is showing an error when trying to. This fix detects it and avoid the konnector's crash if so.

⚠️ Should not be merged until new version of cozy-clisk has been released, otherwise konnector wont work properly ⚠️ 