### PR TITLE
[SCR-737] fix: Use uniquely data-oevent-action identifier for some selectors

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -205,7 +205,7 @@ class OrangeContentScript extends ContentScript {
     const isDisconnected = elcosHeader
       ? Boolean(
           elcosHeader.shadowRoot.querySelector(
-            'a[data-oevent-action=identifiezvous]'
+            '[data-oevent-action=identifiezvous]'
           )
         )
       : false
@@ -266,7 +266,7 @@ class OrangeContentScript extends ContentScript {
       await this.evaluateInWorker(() => {
         document
           .querySelector('#o-header > elcos-header')
-          .shadowRoot.querySelector('a[data-oevent-action=identifiezvous]')
+          .shadowRoot.querySelector('[data-oevent-action=seconnecter]')
           .click()
       })
     } else {
@@ -337,7 +337,7 @@ class OrangeContentScript extends ContentScript {
     const isDisconnectElementPresent = elcosHeader
       ? Boolean(
           elcosHeader.shadowRoot.querySelector(
-            'a[data-oevent-action=identifiezvous]'
+            '[data-oevent-action=identifiezvous]'
           )
         )
       : false


### PR DESCRIPTION
Remove specifique "a" element selector from some selectors. Website changed it for buttons et modify some of the textContent. This fixes the konnector with the dev account.

Still getting 403 on recents files, I'll let this PR open for few moments while verifying if it is still impossible or not.

Edit: 
We are still getting 403 as a desktop user, nothing to do to fix it for now, it's on the website side