### PR TITLE
Fix/login and old bills

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,8 @@ const ERROR_URL = 'https://e.orange.fr/error403.html?ref=idme-ssr&status=error'
 const BASE_URL = 'https://www.orange.fr/portail'
 const DEFAULT_PAGE_URL = 'https://espace-client.orange.fr/accueil'
 let FORCE_FETCH_ALL = false
+// For test purpose
+// let FORCE_FETCH_ALL = true
 const interceptor = new XhrInterceptor()
 interceptor.init()
 
@@ -462,6 +464,7 @@ class OrangeContentScript extends ContentScript {
       // oldbillsUrl might not be present in the intercepted response
       // Perhaps it will appears differently if it does (when newly created contract will have an history to show)
       // Fortunately the account we dispose to develop has just been migrated to this new handling so we might be able to do something when it happen
+      // const testFullsync = true
       if (forceFullSync && oldBillsUrl) {
         const oldBills = await this.fetchOldBills({
           oldBillsUrl,
@@ -748,14 +751,19 @@ class OrangeContentScript extends ContentScript {
   async getOldBillsFromWorker(oldBillsUrl) {
     const OLD_BILLS_URL_PREFIX =
       'https://espace-client.orange.fr/ecd_wp/facture/historicBills'
-    return await ky
-      .get(OLD_BILLS_URL_PREFIX + oldBillsUrl, {
-        headers: {
-          ...ORANGE_SPECIAL_HEADERS,
-          ...JSON_HEADERS
-        }
-      })
-      .json()
+    const response = await ky.get(OLD_BILLS_URL_PREFIX + oldBillsUrl, {
+      headers: {
+        ...ORANGE_SPECIAL_HEADERS,
+        ...JSON_HEADERS
+      }
+    })
+    this.log('debug', `oldBills response status : ${response.status}`)
+    if (response.status === 204) {
+      this.log('warn', 'Request status is 204, return no content')
+      return { oldBills: [] }
+    }
+    const jsonBills = await response.json()
+    return jsonBills
   }
 
   async getRecentBillsFromInterceptor() {

--- a/src/index.js
+++ b/src/index.js
@@ -175,7 +175,9 @@ class OrangeContentScript extends ContentScript {
 
   getCurrentState() {
     const isErrorUrl = window.location.href.includes('error')
-    const isLoginPage = Boolean(document.querySelector('#login'))
+    // Verify if element is present AND if its value is empty as it is now present on passwordPage and have the user's login as value
+    const isLoginPage = document.querySelector('#login')?.value === ''
+
     const isPasswordAlone = Boolean(
       document.querySelector('#password') && !isLoginPage
     )


### PR DESCRIPTION
Changes occured on the element used to detect loginPage.

Also some accounts can received a 204 when calling the oldBills request. This was inducing an error when trying to loop on the oldBills list, as 204 meaning the response got no content at all.
We now check the status code of the request specificaly for this statusCode and return an oldBills object with an empty array, and a warn in the log so we know why there's no file to download.