### PR TITLE
fix: Login button selector

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -209,7 +209,7 @@ class OrangeContentScript extends ContentScript {
     const isDisconnected = elcosHeader
       ? Boolean(
           elcosHeader.shadowRoot.querySelector(
-            '[data-oevent-action=identifiezvous]'
+            '[data-oevent-action="seconnecter"]'
           )
         )
       : false


### PR DESCRIPTION
The "Se connecter" button had it's selector change, leading the konnector to crash on missing awaited elements. This PR fixes it.