### PR TITLE
feat: Use try/catch to avoid crash on missing element

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -708,7 +708,8 @@ class OrangeContentScript extends ContentScript {
       includesText: 'Infos de contact'
     })
     await this.runInWorker('click', 'p', { includesText: 'Infos de contact' })
-    await Promise.all([
+    // Using allSettle here because we notice some account did not have adresses registered
+    await Promise.allSettled([
       this.waitForElementInWorker(
         'a[data-e2e="btn-contact-info-modifier-votre-identite"]'
       ),
@@ -716,7 +717,7 @@ class OrangeContentScript extends ContentScript {
         'a[data-e2e="btn-contact-info-phone-modifier"]'
       ),
       this.waitForElementInWorker(
-        'a[data-e2e="btn-contact-info-modifier-vos-adresses-postales"]'
+        'a[data-e2e="btn-contact-info-modifier-vos-adresses-postales"]', {timeout: 5000}
       )
     ])
   }

--- a/src/index.js
+++ b/src/index.js
@@ -709,17 +709,23 @@ class OrangeContentScript extends ContentScript {
     })
     await this.runInWorker('click', 'p', { includesText: 'Infos de contact' })
     // Using allSettle here because we notice some account did not have adresses registered
-    await Promise.allSettled([
+    await Promise.all([
       this.waitForElementInWorker(
         'a[data-e2e="btn-contact-info-modifier-votre-identite"]'
       ),
       this.waitForElementInWorker(
         'a[data-e2e="btn-contact-info-phone-modifier"]'
-      ),
-      this.waitForElementInWorker(
-        'a[data-e2e="btn-contact-info-modifier-vos-adresses-postales"]', {timeout: 5000}
       )
     ])
+    // Some users does not have any adresse registered on theur account, we got to treat this separatedly to avoid konnector crashing
+    try{
+      await this.waitForElementInWorker(
+        'a[data-e2e="btn-contact-info-modifier-vos-adresses-postales"]', {timeout: 5000}
+      )
+    }catch(_){
+      // Catch it so it don't crash, no big deal if not available
+      this.log('warn', 'Address element is not present on the page')
+    }
   }
 
   async waitForUserAction(url) {


### PR DESCRIPTION
This PR is fixing the missing element crash occuring when a user did not have any addresses registered in his account. As identity is not mandatory and is already conditionned for missing infos, it should avoid the konnector's crash. Same as Sosh

Edit :

promise.allSettled being relatively recent, it is preferable not to use it to cover older devices/browsers that could not use it. 
Now it is simply done with a try/catch to avoid the crash if the element is not present.